### PR TITLE
Rename dependency module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# DataDome Fastly compute at edge module
+# DataDome Fastly compute module
 
-Documentation available here: https://docs.datadome.co/docs/fastly-compute-at-edge
+Documentation available here: https://docs.datadome.co/docs/fastly-compute
 
 [![Deploy to Fastly](https://deploy.edgecompute.app/button)](https://deploy.edgecompute.app/deploy)

--- a/fastly.toml
+++ b/fastly.toml
@@ -2,10 +2,10 @@
 # https://developer.fastly.com/reference/fastly-toml/
 
 authors = [""]
-description = "Datadome template to use Fastly Compute-at-Edge module"
+description = "Datadome template to use Fastly Compute module"
 language = "javascript"
 manifest_version = 3
-name = "DataDome-Fastly_Compute-at-Edge-template"
+name = "DataDome-Fastly_Compute-template"
 service_id = ""
 
 [scripts]

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "description": "DataDome Fastly Compute@Edge template",
+  "description": "DataDome Fastly Compute template",
   "engines": {
     "node": "^18.0.0 || ^20"
   },
   "dependencies": {
     "@fastly/js-compute": "^3.10.0",
-    "@datadome/fastly-compute-at-edge": "1.0.0"
+    "@datadome/module-fastly-compute": "1.0.0"
   },
   "devDependencies": {
     "webpack": "^5.89.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /// <reference types="@fastly/js-compute" />
 // @ts-ignore
-import { DataDome } from "@datadome/fastly-compute-at-edge";
+import { DataDome } from "@datadome/module-fastly-compute";
 
 addEventListener("fetch", (event) => event.respondWith(DataDome.handleRequest(event)));


### PR DESCRIPTION
Dependency module has been renamed to `@datadome/module-fastly-compute`

This PR renames the dependency so the sample work seamlessly.